### PR TITLE
qteesupplicant.service: make it conditional to /dev/tee0

### DIFF
--- a/qtee_supplicant/qteesupplicant.service.in
+++ b/qtee_supplicant/qteesupplicant.service.in
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 [Unit]
 Description=QTEE Supplicant Service
-BindsTo=dev-tee0.device
-After=dev-tee0.device sfsconfig.service
+ConditionPathExists=/dev/tee0
+After=sfsconfig.service
 
 [Service]
 Type=exec


### PR DESCRIPTION
Remove bindsto and after dev-tee0.device and replace with a conditional in order for systemd to not force a wait timeout on devices without the tee device node.