### PR TITLE
qtee_supplicant: stop using MINKIPC_LIBEXEC_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ include(GNUInstallDirs)
 set(MINKIDLC_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idlc" CACHE PATH "Directory containing the idlc executable")
 set(SYSTEMD_UNIT_DIR "" CACHE PATH "Directory containing the systemd unit path")
 set(UDEV_DIR "" CACHE PATH "Directory containing the UDEV path")
-set(MINKIPC_LIBEXEC_DIR "" CACHE PATH "Directory containing the libexec script/binaries path")
 set(PERSIST_MOUNT_UNIT "" CACHE PATH "Name of the systemd unit responsible for mounting the persist partition")
 
 if ("${MINKIDLC_BIN_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/idlc")

--- a/qtee_supplicant/CMakeLists.txt
+++ b/qtee_supplicant/CMakeLists.txt
@@ -46,10 +46,10 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_BINDIR}")
-if (DEFINED MINKIPC_LIBEXEC_DIR AND NOT "${MINKIPC_LIBEXEC_DIR}" STREQUAL "")
-	configure_file(sfs_config.in sfs_config @ONLY)
-	install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/sfs_config" DESTINATION "${MINKIPC_LIBEXEC_DIR}")
-endif()
+
+configure_file(sfs_config.in sfs_config @ONLY)
+install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/sfs_config" DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
+
 if (DEFINED SYSTEMD_UNIT_DIR AND NOT "${SYSTEMD_UNIT_DIR}" STREQUAL "")
 	configure_file(qteesupplicant.service.in qteesupplicant.service @ONLY)
 	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qteesupplicant.service" DESTINATION "${SYSTEMD_UNIT_DIR}")

--- a/qtee_supplicant/sfsconfig.service.in
+++ b/qtee_supplicant/sfsconfig.service.in
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 [Unit]
 Description=SFS Configuration Service
-SourcePath=@MINKIPC_LIBEXEC_DIR@/sfs_config
+SourcePath=@CMAKE_INSTALL_FULL_LIBEXECDIR@/sfs_config
 After=@PERSIST_MOUNT_UNIT@
 Wants=@PERSIST_MOUNT_UNIT@
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=@MINKIPC_LIBEXEC_DIR@/sfs_config
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/sfs_config
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Replace MINKIPC_LIBEXEC_DIR with the usage of the standard libexec paths as set by the GNUInstallDirs.

CRs-Fixed: 4521811