### PR TITLE
Enable libcbor fallback when QCBOR is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ The following CMake options are available for configuring this package:
 
 `-DBUILD_MINKTEEC=ON` - Build Mink TEEC library
 
+Incase, QCBOR dependency is unment, the build system falls back to use libcbor [here](https://github.com/PJK/libcbor).
+
+Libcbor can be installed on Ubuntu/Debian using:
+```
+sudo dpkg --add-architecture arm64
+sudo apt-get update
+sudo apt-get install libcbor-dev:arm64
+```
+
 ## Tests
 List of available tests for each module are available in the module's README file.
 

--- a/libminkadaptor/CMakeLists.txt
+++ b/libminkadaptor/CMakeLists.txt
@@ -35,7 +35,7 @@ set(QCBOR_DIR_HINT "" CACHE PATH "Hint path for QCBOR directory")
 
 find_package(QCBOR REQUIRED)
 if(NOT QCBOR_FOUND)
-       message(FATAL_ERROR "QCBOR not found")
+	message(WARNING "QCBOR not found, falling back to libcbor")
 endif()
 
 # ''Source files''.
@@ -71,11 +71,19 @@ target_include_directories(minkadaptor
 	PRIVATE src
 )
 
-target_link_libraries(minkadaptor
-	PRIVATE ${QCOMTEE_LIBRARIES}
-	PRIVATE ${QCBOR_LIBRARIES}
-	PRIVATE ${CMAKE_THREAD_LIBS_INIT}
-)
+if (QCBOR_FOUND)
+	target_link_libraries(minkadaptor
+		PRIVATE ${QCOMTEE_LIBRARIES}
+		PRIVATE ${QCBOR_LIBRARIES}
+		PRIVATE ${CMAKE_THREAD_LIBS_INIT}
+	)
+else()
+	target_link_libraries(minkadaptor
+		PRIVATE ${QCOMTEE_LIBRARIES}
+		PRIVATE cbor
+		PRIVATE ${CMAKE_THREAD_LIBS_INIT}
+	)
+endif()
 
 # ''Install targets''.
 

--- a/libminkadaptor/tests/smcinvoke_client/CMakeLists.txt
+++ b/libminkadaptor/tests/smcinvoke_client/CMakeLists.txt
@@ -8,8 +8,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(QCBOR_DIR_HINT "" CACHE PATH "Hint path for QCBOR directory")
 
 find_package(QCBOR REQUIRED)
-if(NOT QCBOR_FOUND)
-	message(FATAL_ERROR "QCBOR not found")
+if(QCBOR_FOUND)
+	add_compile_definitions(${PROJECT_NAME}
+		PRIVATE -DUSE_QCBOR)
+else()
+	message(WARNING "QCBOR not found, falling back to libcbor")
 endif()
 
 include_directories(${QCBOR_INCLUDE_DIRS})
@@ -84,9 +87,16 @@ target_include_directories(${PROJECT_NAME}
 	PRIVATE idl
 )
 
-target_link_libraries(${PROJECT_NAME}
-	PRIVATE minkadaptor
-	PRIVATE ${QCBOR_LIBRARIES}
-)
+if(QCBOR_FOUND)
+	target_link_libraries(${PROJECT_NAME}
+		PRIVATE minkadaptor
+		PRIVATE ${QCBOR_LIBRARIES}
+	)
+else()
+	target_link_libraries(${PROJECT_NAME}
+		PRIVATE minkadaptor
+		PRIVATE cbor
+	)
+endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/libminkadaptor/tests/smcinvoke_client/src/smcinvoke_client.cpp
+++ b/libminkadaptor/tests/smcinvoke_client/src/smcinvoke_client.cpp
@@ -29,7 +29,12 @@
 #include "MinkCom.h"
 #include "tzecotestapp_uids.h"
 #include "tzt.h"
+#ifdef USE_QCBOR
 #include <qcbor/qcbor.h>
+#else
+#include <cbor.h>
+#include <string.h>
+#endif
 
 int32_t create_and_assign_mem_obj(Object, Object *);
 
@@ -61,6 +66,7 @@ static int64_t get_time_in_ms(void)
 	return (int64_t)(tv.tv_sec * 1000) + (int64_t)(tv.tv_usec / 1000);
 }
 
+#ifdef USE_QCBOR
 static int realloc_useful_buf(UsefulBuf *buf)
 {
 	void *ptr;
@@ -105,6 +111,60 @@ static void* get_self_creds(size_t *buf_len)
 
 	return credential_buf;
 }
+#else
+static void* get_self_creds(size_t *buf_len)
+{
+	cbor_mutable_data buffer = NULL;
+	void *credential_buf = nullptr;
+	cbor_item_t *creds_map = NULL;
+	struct cbor_pair map_pair;
+	size_t buffer_size = CREDENTIALS_BUF_SIZE_INC;
+
+	buffer = (unsigned char *)calloc(buffer_size, sizeof(unsigned char));
+	if (buffer == NULL)
+		return NULL;
+
+	creds_map = cbor_new_definite_map(2);
+	if (creds_map == NULL)
+		goto map_init_fail;
+
+	map_pair.key = cbor_build_uint8(attr_uid);
+	map_pair.value = cbor_build_uint32((uint64_t)getuid());
+	if (!cbor_map_add(creds_map, map_pair))
+		goto map_add_fail;
+
+	map_pair.key = cbor_build_uint8(attr_system_time);
+	map_pair.value = cbor_build_uint64((uint64_t)get_time_in_ms());
+	if (!cbor_map_add(creds_map, map_pair))
+		goto map_add_fail;
+
+        /*
+         * On failure in serialization we jump to map_serialize_fail
+         * because cbor_decref() recursively frees all items already
+         * added to the map. However, if cbor_map_add() fails, we
+         * must manually decref the current key/value as ownership
+         * is not transferred.
+         */
+	buffer_size = cbor_serialize_map(creds_map, buffer, buffer_size);
+	if (buffer_size == 0)
+		goto map_serialize_fail;
+
+	credential_buf = (void *)buffer;
+	*buf_len = buffer_size;
+
+	cbor_decref(&creds_map);
+	return credential_buf;
+
+map_add_fail:
+	cbor_decref(&map_pair.key);
+	cbor_decref(&map_pair.value);
+map_serialize_fail:
+	cbor_decref(&creds_map);
+map_init_fail:
+	free(buffer);
+	return NULL;
+}
+#endif
 
 int32_t create_and_assign_mem_obj(Object root, Object *argptr)
 {


### PR DESCRIPTION
The libminkadaptor library statically links libqcomtee, which currently relies on QCBOR as its primary CBOR implementation.
However, QCBOR is not available in many common Linux distributions, including Debian and Fedora, which complicates building and packaging downstream components.

Libqcomtee already supports a fallback to libcbor in environments where QCBOR is not present. This change ensures that libminkadaptor correctly follows that configuration and links against the same CBOR backend selected when libqcomtee is built against libcbor when QCBOR is absent.

In addition, smcinvoke_client, which previously depended directly on QCBOR, is updated to follow the same approach as libqcomtee and use libcbor when QCBOR is not present. This unifies CBOR handling across the stack and avoids hard dependencies on QCBOR.

By supporting libcbor as a fallback, qcomtee and its consumers become easier to build and use across a broader range of Linux distributions, while maintaining CBOR compatibility and interoperability with existing TrustZone firmware.

Depends on: https://github.com/quic/quic-teec/pull/23

Signed-off-by: Abhinaba Rakshit [abhinaba.rakshit@oss.qualcomm.com](mailto:abhinaba.rakshit@oss.qualcomm.com)
CRs-Fixed: 4487253