### PR TITLE
Set idlc binary permission only on download scenarios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,8 @@ if ("${MINKIDLC_BIN_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/idlc")
 	https://github.com/quic/mink-idl-compiler/releases/download/v0.2.0/idlc
 	${MINKIDLC_BIN_DIR}/idlc
 	)
+	file(CHMOD ${MINKIDLC_BIN_DIR}/idlc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 endif()
-
-file(CHMOD ${MINKIDLC_BIN_DIR}/idlc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 
 add_compile_options(
 	-Wall -Wextra -Werror -Wshadow -Wcast-align


### PR DESCRIPTION
Not all build environments permit modifying file permissions of binaries that are installed or placed on the host filesystem. One such example is the Debian sbuild environment, which enforces strict restrictions on modifying files outside the build directory.

As a result, permission updates for the Mink IDL compiler (idlc) should be performed only when the binary is downloaded directly from the official mink-idl-compiler GitHub archive, where the executable permission is not preserved. In this specific case, setting the appropriate permissions is necessary to ensure the tool can be executed during the build.

In all other scenarios—such as when the idlc binary is provided or managed externally by the user (or installed through package)—it is considered the user’s responsibility to ensure that the binary has the correct permissions. To remain compliant with restricted build environments and packaging policies, the CMakeLists.txt logic should avoid modifying permissions within the host's root filesystem.

Signed-off-by: Abhinaba Rakshit [abhinaba.rakshit@oss.qualcomm.com](mailto:abhinaba.rakshit@oss.qualcomm.com)
CRs-Fixed: 4529818