### PR TITLE
CI: Enable matrix-based CI builds using build_matrix.json

### DIFF
--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -1,4 +1,3 @@
----
 name: Load Parameters
 description: Load parameters for the build job
 
@@ -17,23 +16,34 @@ runs:
         script: |
           const fs = require('fs');
           const path = require('path');
-          const ConfigPath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'CONFIG.json');
+
+          const ConfigPath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'build_matrix.json');
           let Config;
+
           try {
             if (!fs.existsSync(ConfigPath)) {
-              core.setFailed(`CONFIG.json not found at ${ConfigPath}`);
+              core.setFailed(`build_matrix.json not found at ${ConfigPath}`);
               return;
             }
             Config = JSON.parse(fs.readFileSync(ConfigPath, 'utf-8'));
           } catch (err) {
-            core.setFailed(`Failed to load or parse CONFIG.json: ${err.message}`);
+            core.setFailed(`Failed to load or parse build_matrix.json: ${err.message}`);
             return;
           }
-          // Build matrix: os, kernel, firmware
-          const build_matrix = Object.values(Config).map(obj => Object.fromEntries(Object.entries(obj)));
+
+          // build_matrix.json must already be in the form:
+          // { "include": [ ... ] }
+          if (!Config || !Array.isArray(Config.include)) {
+            core.setFailed('build_matrix.json must contain an "include" array');
+            return;
+          }
+
+          const build_matrix = Config;
+
+          console.log(JSON.stringify(build_matrix, null, 2));
           core.setOutput('build_matrix', JSON.stringify(build_matrix));
           console.log("Build Matrix:", build_matrix);
-          // summary
+
           const md = [
             '# Repositories to build',
             '',
@@ -41,4 +51,5 @@ runs:
             JSON.stringify(build_matrix, null, 2),
             '```'
           ].join('\n');
+
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');

--- a/.github/workflows/sync_build.yml
+++ b/.github/workflows/sync_build.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
       build_matrix:
-        description: build matrix containing repos
+        description: build matrix containing targets
         type: string
         required: true
 
@@ -47,16 +47,26 @@ on:
         value: ${{ jobs.build.outputs.s3_location }}
 
 env:
-  RB3GEN2_ROOTFS_KEY: qualcomm/qcom-multimedia-image-rb3gen2-core-kit.rootfs.qcomflash.tar.gz
   S3_BUCKET: qli-prd-ssg-gh-artifacts
 
 jobs:
   build:
+    name: Build ${{ matrix.name }}
+
     # If you need the runner group syntax, you can use the block form:
     runs-on:
       group: GHA-SSG-Prd-SelfHosted-RG
       labels: [self-hosted,ssg-prd-u2204-x64-large-od-ephem]
     
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.build_matrix) }}
+
+    env:
+      ROOTFS_KEY: ${{ matrix.rootfs_key }}
+      MODIFIED_TAR_NAME: ${{ matrix.modified_tar_name || inputs.modified_tar_name }}
+      ARTIFACT_DIR: ${{ matrix.artifact_dir || 'MINKIPC_LIBS' }}
+
     outputs:
       workspace_path: ${{ steps.sync.outputs.workspace_path }}
     steps:
@@ -64,6 +74,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Show target
+        run: |
+          echo "Building target: ${{ matrix.name }}"
+          echo "Rootfs key: ${{ env.ROOTFS_KEY }}"
+          echo "Artifact dir: ${{ env.ARTIFACT_DIR }}"
+          echo "Modified tar name: ${{ env.MODIFIED_TAR_NAME }}"
 
       - name: Pull docker image
         uses: qualcomm/minkipc/.github/actions/pull_docker_image@main
@@ -290,7 +307,7 @@ jobs:
           ART_DIR="${GITHUB_WORKSPACE}/artifacts"
           mkdir -p "${ART_DIR}"
 
-          MOD_TAR="${ART_DIR}/${{ inputs.modified_tar_name }}"
+          MOD_TAR="${ART_DIR}/${MODIFIED_TAR_NAME}"
 
           # Read normalized top-levels
           IFS=' ' read -r -a TOPLEVELS <<< "${{ steps.orig_tar_meta.outputs.TOPLEVELS }}"
@@ -322,6 +339,7 @@ jobs:
         uses: qualcomm/minkipc/.github/actions/aws_s3_helper@main
         with:
           s3_bucket: qli-prd-ssg-gh-artifacts
+          s3_prefix: ${{ matrix.name }}
           local_file: ${{ github.workspace }}/../artifacts/file_list.txt
           mode: multi-upload
 

--- a/ci/build_matrix.json
+++ b/ci/build_matrix.json
@@ -1,0 +1,22 @@
+{
+  "include": [
+    {
+      "name": "rb3gen2",
+      "rootfs_key": "qualcomm/qcom-multimedia-image-rb3gen2-core-kit.rootfs.qcomflash.tar.gz",
+      "modified_tar_name": "ssg-qcom-multimedia-image-rb3gen2-core-kit.rootfs.qcomflash.tar.gz",
+      "artifact_dir": "MINKIPC_LIBS"
+    },
+    {
+      "name": "qcs8300",
+      "rootfs_key": "qualcomm/qcom-multimedia-proprietary-image-qcs8300-ride-sx.rootfs.qcomflash.tar.gz",
+      "modified_tar_name": "ssg-qcom-multimedia-proprietary-image-qcs8300-ride-sx.rootfs.qcomflash.tar.gz",
+      "artifact_dir": "MINKIPC_LIBS"
+    },
+    {
+      "name": "qcs9100",
+      "rootfs_key": "qualcomm/qcom-multimedia-proprietary-image-qcs9100-ride-sx.rootfs.qcomflash.tar.gz",
+      "modified_tar_name": "ssg-qcom-multimedia-proprietary-image-qcs9100-ride-sx.rootfs.qcomflash.tar.gz",
+      "artifact_dir": "MINKIPC_LIBS"
+    }
+  ]
+}


### PR DESCRIPTION
The current CI pipeline supports only single-target build and test execution.
This migrate the CI pipeline from a single-target execution model to a matrix-based multi-target build and test ci pipeline.

Key Changes:

- Introduce Matrix Configuration: Add ci/build_matrix.json as the primary source of truth for all build targets, replacing the legacy single-target configuration.

- Update Loading Action: Modify the parameters loading action to parse and validate the build_matrix.json structure and output it as a GitHub Actions-compatible matrix object.

- Dynamic Workflow Expansion: Update sync_build.yml to utilize the strategy/matrix syntax, enabling parallel execution across all targets defined in the matrix.

- Target-Specific Overrides: Implement environment variable overrides for ROOTFS_KEY, ARTIFACT_DIR, and MODIFIED_TAR_NAME within the matrix scope to ensure unique build environments per target based on nightly meta-qcom builds.

CRs-Fixed: 4538047