### PR TITLE
CI: Replace pull_request_target to reduce runner exposure

### DIFF
--- a/.github/actions/build_minkipc/action.yml
+++ b/.github/actions/build_minkipc/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     default: ssg-image:v1.0
   event_name:
-    description: Event type that triggered the workflow (e.g., pull_request_target, push, workflow_call)
+    description: Event type that triggered the workflow (e.g., pull_request, push, workflow_call)
     required: true
   pr_ref:
     description: PR branch ref (e.g., feature/my-feature)

--- a/.github/actions/build_qcbor/action.yml
+++ b/.github/actions/build_qcbor/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     default: ssg-image:v1.0
   event_name:
-    description: Event type that triggered the workflow (e.g., pull_request_target, push, workflow_call)
+    description: Event type that triggered the workflow (e.g., pull_request, push, workflow_call)
     required: true
 
 outputs:

--- a/.github/actions/build_quic-teec/action.yml
+++ b/.github/actions/build_quic-teec/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     default: ssg-image:v1.0
   event_name:
-    description: Event type that triggered the workflow (e.g., pull_request_target, push, workflow_call)
+    description: Event type that triggered the workflow (e.g., pull_request, push, workflow_call)
     required: true
 
 outputs:

--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -4,7 +4,7 @@ description: Action to sync the codebase based on the trigger event.
 
 inputs:
   event_name:
-    description: Event type that triggered the workflow (e.g., pull_request_target, push, workflow_call)
+    description: Event type that triggered the workflow (e.g., pull_request, push, workflow_call)
     required: true
   pr_ref:
     description: PR branch ref (e.g., feature/my-feature)
@@ -19,8 +19,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout Code (pull_request_target)
-      if: ${{ (inputs.event_name == 'pull_request_target' || inputs.event_name == 'workflow_call') && inputs.pr_ref != '' && inputs.pr_repo != '' }}
+    - name: Checkout Code (pull_request)
+      if: ${{ (inputs.event_name == 'pull_request' || inputs.event_name == 'workflow_call') && inputs.pr_ref != '' && inputs.pr_repo != '' }}
       uses: actions/checkout@v5   # actions/checkout@v5
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 set -euo pipefail
 
 # This script will be used for ARMOR tool 


### PR DESCRIPTION
Replace pull_request_target usage with pull_request where possible to reduce the risk of arbitrary code execution and secret exposure on self-hosted runners

CRs-Fixed: 4538047