### PR TITLE
Add distro-specific user/group overrides for systemd services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ set(MINKIDLC_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idlc" CACHE PATH "Directory co
 set(SYSTEMD_UNIT_DIR "" CACHE PATH "Directory containing the systemd unit path")
 set(UDEV_DIR "" CACHE PATH "Directory containing the UDEV path")
 set(PERSIST_MOUNT_UNIT "" CACHE PATH "Name of the systemd unit responsible for mounting the persist partition")
+set(DISTRO_USER "root" CACHE STRING "Distro specific user for systemd service and devices")
+set(DISTRO_GROUP "root" CACHE STRING "Distro specific group for the systemd service devices")
 
 if ("${MINKIDLC_BIN_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/idlc")
 	file(DOWNLOAD

--- a/qtee_supplicant/qcomtee-udev.rules.in
+++ b/qtee_supplicant/qcomtee-udev.rules.in
@@ -1,4 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", TAG+="systemd" ENV{SYSTEMD_WANTS}+="qteesupplicant.service"
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="@DISTRO_GROUP@", TAG+="systemd" ENV{SYSTEMD_WANTS}+="qteesupplicant.service"
+KERNEL=="0:0:0:49476", SUBSYSTEM=="bsg", MODE="0660", OWNER="root", GROUP="@DISTRO_GROUP@", TAG+="systemd" ENV{SYSTEMD_WANTS}+="qteesupplicant.service"
+KERNEL=="ufs-bsg0", SUBSYSTEM=="bsg", MODE="0660", OWNER="root", GROUP="@DISTRO_GROUP@", TAG+="systemd" ENV{SYSTEMD_WANTS}+="qteesupplicant.service"
+KERNEL=="mmcblk0rpmb", SUBSYSTEM=="mmc_rpmb", MODE="0660", OWNER="root", GROUP="@DISTRO_GROUP@", TAG+="systemd" ENV{SYSTEMD_WANTS}+="qteesupplicant.service"

--- a/qtee_supplicant/qteesupplicant.service.in
+++ b/qtee_supplicant/qteesupplicant.service.in
@@ -6,6 +6,10 @@ BindsTo=dev-tee0.device
 After=dev-tee0.device sfsconfig.service
 
 [Service]
+User=@DISTRO_USER@
+Group=@DISTRO_GROUP@
+AmbientCapabilities=CAP_SYS_RAWIO
+CapabilityBoundingSet=CAP_SYS_RAWIO
 Type=exec
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/qtee_supplicant
 Restart=always


### PR DESCRIPTION
Previously, qteesupplicant service and other resources configured from udev rules were defaulted to running as root. Running services as root is discouraged as it violates the principle of least privilege.

Additionally, running services and their resources under separate user/group provides better isolation among QTEE services and prevents tampering by other users.

This change introduces two CMake cache variables, DISTRO_USER and DISTRO_GROUP (both defaulting to "root"), allowing distros to configure the owning user and group independently. The values are substituted into the qteesupplicant unit files, as well as the qcomtee udev rules.

Also adds udev rules for UFS and eMMC RPMB devices to configure them with the same user and group.

The sfsconfig service is not provided with a separate user and group and remains as root, since it is a one-shot service responsible only for creating directories.

Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>
CRs-Fixed: 4560808