### PR TITLE
Fix compilation warnings in librpmbservice

### DIFF
--- a/listeners/librpmbservice/rpmb.c
+++ b/listeners/librpmbservice/rpmb.c
@@ -119,16 +119,22 @@ void rpmb_init_wakelock(void)
 
 void rpmb_wakelock(void)
 {
-	if (g_wakelock.lock_fd >= 0)
-		(void)write(g_wakelock.lock_fd, WAKELOCK_NAME,
-			    (size_t)g_wakelock.name_len);
+	if (g_wakelock.lock_fd >= 0) {
+		ssize_t ret = write(g_wakelock.lock_fd, WAKELOCK_NAME,
+				    (size_t)g_wakelock.name_len);
+		if (ret != g_wakelock.name_len)
+			RPMB_LOG_WARN("Failed to acquire wakelock\n");
+	}
 }
 
 void rpmb_wakeunlock(void)
 {
-	if (g_wakelock.unlock_fd >= 0)
-		(void)write(g_wakelock.unlock_fd, WAKELOCK_NAME,
-			    (size_t)g_wakelock.name_len);
+	if (g_wakelock.unlock_fd >= 0) {
+		ssize_t ret = write(g_wakelock.unlock_fd, WAKELOCK_NAME,
+				    (size_t)g_wakelock.name_len);
+		if (ret != g_wakelock.name_len)
+			RPMB_LOG_WARN("Failed to release wakelock\n");
+	}
 }
 
 /* -----------------------------------------------------------------------

--- a/listeners/librpmbservice/rpmb_emmc.c
+++ b/listeners/librpmbservice/rpmb_emmc.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
@@ -229,40 +230,49 @@ int rpmb_emmc_read(uint32_t *req_buf, uint32_t blk_cnt,
 		   uint32_t *resp_buf, uint32_t *resp_len)
 {
 	/*
-	 * Stack-allocate the multi-cmd struct (2 commands).
-	 * mmc_ioc_multi_cmd has a flexible array member, so we use a
-	 * wrapper struct to give it the right size on the stack.
+	 * mmc_ioc_multi_cmd ends in a flexible array member (cmds[]), so it
+	 * must be heap-allocated with room for the commands we use. A stack
+	 * wrapper struct does not work: GCC's -Warray-bounds (under -O2)
+	 * traces cmds[1] back to the fixed-size wrapper and errors out.
+	 * Heap allocation sizes the array at runtime, which the static
+	 * checker cannot flag. This matches the mmc-utils reference idiom.
 	 */
-	struct {
-		struct mmc_ioc_multi_cmd multi;
-		struct mmc_ioc_cmd extra[1]; /* room for cmd[1] */
-	} mc;
+	const uint32_t num_cmds = 2;
+	struct mmc_ioc_multi_cmd *mc;
+	struct mmc_ioc_cmd *cmds;
 	int ret;
+
+	mc = calloc(1, sizeof(*mc) + num_cmds * sizeof(struct mmc_ioc_cmd));
+	if (!mc) {
+		RPMB_LOG_ERROR("eMMC RPMB read: out of memory\n");
+		*resp_len = 0;
+		return -1;
+	}
+	cmds = mc->cmds;
 
 	rpmb_wakelock();
 
-	memset(&mc, 0, sizeof(mc));
-	mc.multi.num_of_cmds = 2;
+	mc->num_of_cmds = num_cmds;
 
 	/* CMD25 -- write 1 request frame */
-	mc.multi.cmds[0].write_flag = 1;
-	mc.multi.cmds[0].opcode = MMC_WRITE_MULTIPLE_BLOCK;
-	mc.multi.cmds[0].arg = 0;
-	mc.multi.cmds[0].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	mc.multi.cmds[0].blksz = RPMB_BLK_SIZE;
-	mc.multi.cmds[0].blocks = RPMB_MIN_BLK_CNT;
-	mmc_ioc_cmd_set_data(mc.multi.cmds[0], req_buf);
+	cmds[0].write_flag = 1;
+	cmds[0].opcode = MMC_WRITE_MULTIPLE_BLOCK;
+	cmds[0].arg = 0;
+	cmds[0].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmds[0].blksz = RPMB_BLK_SIZE;
+	cmds[0].blocks = RPMB_MIN_BLK_CNT;
+	mmc_ioc_cmd_set_data(cmds[0], req_buf);
 
 	/* CMD18 -- read blk_cnt response frames */
-	mc.multi.cmds[1].write_flag = 0;
-	mc.multi.cmds[1].opcode = MMC_READ_MULTIPLE_BLOCK;
-	mc.multi.cmds[1].arg = 0;
-	mc.multi.cmds[1].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	mc.multi.cmds[1].blksz = RPMB_BLK_SIZE;
-	mc.multi.cmds[1].blocks = blk_cnt;
-	mmc_ioc_cmd_set_data(mc.multi.cmds[1], resp_buf);
+	cmds[1].write_flag = 0;
+	cmds[1].opcode = MMC_READ_MULTIPLE_BLOCK;
+	cmds[1].arg = 0;
+	cmds[1].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmds[1].blksz = RPMB_BLK_SIZE;
+	cmds[1].blocks = blk_cnt;
+	mmc_ioc_cmd_set_data(cmds[1], resp_buf);
 
-	ret = ioctl(rpmb.fd, MMC_IOC_MULTI_CMD, &mc.multi);
+	ret = ioctl(rpmb.fd, MMC_IOC_MULTI_CMD, mc);
 
 	if (ret) {
 		RPMB_LOG_ERROR("eMMC RPMB read ioctl failed: %s\n",
@@ -272,6 +282,7 @@ int rpmb_emmc_read(uint32_t *req_buf, uint32_t blk_cnt,
 		*resp_len = blk_cnt * RPMB_BLK_SIZE;
 	}
 
+	free(mc);
 	rpmb_wakeunlock();
 	return ret;
 }
@@ -293,14 +304,14 @@ int rpmb_emmc_write(uint32_t *req_buf, uint32_t blk_cnt,
 {
 	struct rpmb_frame result_frame;
 	/*
-	 * Stack-allocate the multi-cmd struct (3 commands).
-	 * mmc_ioc_multi_cmd has a flexible array (cmds[0]), so the wrapper
-	 * struct gives us room for cmds[0], cmds[1], and cmds[2].
+	 * mmc_ioc_multi_cmd ends in a flexible array member (cmds[]), so it
+	 * must be heap-allocated with room for the commands we use. See the
+	 * note in rpmb_emmc_read() -- a stack wrapper trips -Warray-bounds
+	 * under -O2; runtime allocation does not.
 	 */
-	struct {
-		struct mmc_ioc_multi_cmd multi;
-		struct mmc_ioc_cmd extra[2];
-	} mc;
+	const uint32_t num_cmds = 3;
+	struct mmc_ioc_multi_cmd *mc;
+	struct mmc_ioc_cmd *cmds;
 	int ret = 0, i, num_rpmb_trans;
 
 	if (frames_per_rpmb_trans == 0) {
@@ -316,6 +327,14 @@ int rpmb_emmc_write(uint32_t *req_buf, uint32_t blk_cnt,
 		return -1;
 	}
 
+	mc = calloc(1, sizeof(*mc) + num_cmds * sizeof(struct mmc_ioc_cmd));
+	if (!mc) {
+		RPMB_LOG_ERROR("eMMC RPMB write: out of memory\n");
+		*resp_len = 0;
+		return -1;
+	}
+	cmds = mc->cmds;
+
 	rpmb_wakelock();
 
 	num_rpmb_trans = blk_cnt / frames_per_rpmb_trans;
@@ -325,39 +344,38 @@ int rpmb_emmc_write(uint32_t *req_buf, uint32_t blk_cnt,
 		      blk_cnt, num_rpmb_trans,
 		      frames_per_rpmb_trans, rpmb.info.rel_wr_count);
 
-	memset(&mc, 0, sizeof(mc));
-	mc.multi.num_of_cmds = 3;
+	mc->num_of_cmds = num_cmds;
 
 	/* CMD25 -- write data frames (reliable write); data ptr set per-loop */
-	mc.multi.cmds[0].write_flag = 1 | SECURE_WRITE;
-	mc.multi.cmds[0].opcode = MMC_WRITE_MULTIPLE_BLOCK;
-	mc.multi.cmds[0].arg = 0;
-	mc.multi.cmds[0].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	mc.multi.cmds[0].blksz = RPMB_BLK_SIZE;
-	mc.multi.cmds[0].blocks = frames_per_rpmb_trans;
+	cmds[0].write_flag = 1 | SECURE_WRITE;
+	cmds[0].opcode = MMC_WRITE_MULTIPLE_BLOCK;
+	cmds[0].arg = 0;
+	cmds[0].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmds[0].blksz = RPMB_BLK_SIZE;
+	cmds[0].blocks = frames_per_rpmb_trans;
 
 	/* CMD25 -- write result-read-request frame */
-	mc.multi.cmds[1].write_flag = 1;
-	mc.multi.cmds[1].opcode = MMC_WRITE_MULTIPLE_BLOCK;
-	mc.multi.cmds[1].arg = 0;
-	mc.multi.cmds[1].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	mc.multi.cmds[1].blksz = RPMB_BLK_SIZE;
-	mc.multi.cmds[1].blocks = RPMB_MIN_BLK_CNT;
+	cmds[1].write_flag = 1;
+	cmds[1].opcode = MMC_WRITE_MULTIPLE_BLOCK;
+	cmds[1].arg = 0;
+	cmds[1].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmds[1].blksz = RPMB_BLK_SIZE;
+	cmds[1].blocks = RPMB_MIN_BLK_CNT;
 
 	/* CMD18 -- read result frame */
-	mc.multi.cmds[2].write_flag = 0;
-	mc.multi.cmds[2].opcode = MMC_READ_MULTIPLE_BLOCK;
-	mc.multi.cmds[2].arg = 0;
-	mc.multi.cmds[2].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	mc.multi.cmds[2].blksz = RPMB_BLK_SIZE;
-	mc.multi.cmds[2].blocks = RPMB_MIN_BLK_CNT;
+	cmds[2].write_flag = 0;
+	cmds[2].opcode = MMC_READ_MULTIPLE_BLOCK;
+	cmds[2].arg = 0;
+	cmds[2].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmds[2].blksz = RPMB_BLK_SIZE;
+	cmds[2].blocks = RPMB_MIN_BLK_CNT;
 
 	for (i = 0; i < num_rpmb_trans; i++) {
-		mmc_ioc_cmd_set_data(mc.multi.cmds[0], req_buf);
-		mmc_ioc_cmd_set_data(mc.multi.cmds[1], &read_result_reg_frame);
-		mmc_ioc_cmd_set_data(mc.multi.cmds[2], resp_buf);
+		mmc_ioc_cmd_set_data(cmds[0], req_buf);
+		mmc_ioc_cmd_set_data(cmds[1], &read_result_reg_frame);
+		mmc_ioc_cmd_set_data(cmds[2], resp_buf);
 
-		ret = ioctl(rpmb.fd, MMC_IOC_MULTI_CMD, &mc.multi);
+		ret = ioctl(rpmb.fd, MMC_IOC_MULTI_CMD, mc);
 		if (ret) {
 			RPMB_LOG_ERROR("eMMC RPMB write ioctl failed at"
 				       " trans %d: %s\n", i, strerror(errno));
@@ -395,6 +413,7 @@ int rpmb_emmc_write(uint32_t *req_buf, uint32_t blk_cnt,
 	else
 		*resp_len = RPMB_MIN_BLK_CNT * RPMB_BLK_SIZE;
 
+	free(mc);
 	rpmb_wakeunlock();
 	return ret;
 }


### PR DESCRIPTION
Fixed below warnings:

 [101/166] : && /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -fPIC -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe  -shared -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-z,relro,-z,now -Wl,--dependency-file=libminkteec/CMakeFiles/minkteec.dir/link.d -Wl,-soname,libminkteec.so.1 -o libminkteec/libminkteec.so.1.0.0 libminkteec/CMakeFiles/minkteec.dir/src/tee_client_api.c.o libminkteec/CMakeFiles/minkteec.dir/src/mink_teec.c.o libminkteec/CMakeFiles/minkteec.dir/src/CWait.c.o  -Wl,-rpath,"\$ORIGIN/../libminkadaptor:"  libminkadaptor/libminkadaptor.so.0.1.0 && :
| [102/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c
| FAILED: [code=1] listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c: In function 'rpmb_wakelock':
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c:123:23: error: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Werror=unused-result]
|   123 |                 (void)write(g_wakelock.lock_fd, WAKELOCK_NAME,
|       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   124 |                             (size_t)g_wakelock.name_len);
|       |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c: In function 'rpmb_wakeunlock':
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb.c:130:23: error: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Werror=unused-result]
|   130 |                 (void)write(g_wakelock.unlock_fd, WAKELOCK_NAME,
|       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   131 |                             (size_t)g_wakelock.name_len);
|       |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| cc1: all warnings being treated as errors
| [103/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/__/listenercbo/src/CListenerCBO.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/__/listenercbo/src/CListenerCBO.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/__/listenercbo/src/CListenerCBO.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/listenercbo/src/CListenerCBO.c
| [104/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -DBINARY_PREFIX=\"LT\" -D_GNU_SOURCE -Dckqteec_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/optee-client/optee_client/libckteec/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/optee-client/optee_client/libckteec/src -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkteec/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/optee-client/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wbad-function-cast -Werror-implicit-function-declaration -Wfloat-equal -Wformat-nonliteral -Wformat=2 -Winit-self -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wstrict-prototypes -Wswitch-default -Wwrite-strings -Wno-unterminated-string-initialization -Wunsafe-loop-optimizations -MD -MT optee-client/CMakeFiles/ckqteec.dir/optee_client/libckteec/src/pkcs11_processing.c.o -MF optee-client/CMakeFiles/ckqteec.dir/optee_client/libckteec/src/pkcs11_processing.c.o.d -o optee-client/CMakeFiles/ckqteec.dir/optee_client/libckteec/src/pkcs11_processing.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/optee-client/optee_client/libckteec/src/pkcs11_processing.c
| [105/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/cmake -E cmake_symlink_library libminkteec/libminkteec.so.1.0.0  libminkteec/libminkteec.so.1 libminkteec/libminkteec.so && :
| [106/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_service.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_service.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_service.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_service.c
| [107/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_logging.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_logging.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_logging.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_logging.c
| [108/166] /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c
| FAILED: [code=1] listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native/usr/bin/aarch64-qcom-linux/aarch64-qcom-linux-gcc --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot -Drpmbservice_EXPORTS -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/include -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/../listenercbo/idl -I/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/libminkadaptor/include -march=armv8.2-a+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot  -O2 -g -fcanon-prefix-map  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/build=/usr/src/debug/minkipc/1.2.4  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot=  -ffile-prefix-map=/local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot-native=  -pipe -fPIC -Wall -Wextra -Werror -Wshadow -Wcast-align -Wmissing-declarations -Wformat-security -Wmissing-noreturn -Wdeprecated -fPIC -Wstrict-prototypes -Wmissing-prototypes -Wbad-function-cast -MD -MT listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o -MF listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o.d -o listeners/librpmbservice/CMakeFiles/rpmbservice.dir/rpmb_emmc.c.o -c /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c: In function 'rpmb_emmc_read':
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:257:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   257 |         mc.multi.cmds[1].write_flag = 0;
|       |         ~~~~~~~~~~~~~^~~
| In file included from /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:18:
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:258:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   258 |         mc.multi.cmds[1].opcode = MMC_READ_MULTIPLE_BLOCK;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:259:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   259 |         mc.multi.cmds[1].arg = 0;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:260:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   260 |         mc.multi.cmds[1].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:261:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   261 |         mc.multi.cmds[1].blksz = RPMB_BLK_SIZE;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:262:22: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   262 |         mc.multi.cmds[1].blocks = blk_cnt;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:263:43: error: array subscript 1 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   263 |         mmc_ioc_cmd_set_data(mc.multi.cmds[1], resp_buf);
|       |                              ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c: In function 'rpmb_emmc_write':
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:348:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   348 |         mc.multi.cmds[2].write_flag = 0;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:349:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   349 |         mc.multi.cmds[2].opcode = MMC_READ_MULTIPLE_BLOCK;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:350:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   350 |         mc.multi.cmds[2].arg = 0;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:351:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   351 |         mc.multi.cmds[2].flags = MMC_RSP_R1 | MMC_CMD_ADTC;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:352:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   352 |         mc.multi.cmds[2].blksz = RPMB_BLK_SIZE;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:353:22: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   353 |         mc.multi.cmds[2].blocks = RPMB_MIN_BLK_CNT;
|       |         ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/sources/minkipc-1.2.4/listeners/librpmbservice/rpmb_emmc.c:358:51: error: array subscript 2 is above array bounds of 'struct mmc_ioc_cmd[]' [-Werror=array-bounds=]
|   358 |                 mmc_ioc_cmd_set_data(mc.multi.cmds[2], resp_buf);
|       |                                      ~~~~~~~~~~~~~^~~
| /local/mnt/workspace/qli_2_0/build/tmp/work/armv8-2a-qcom-linux/minkipc/1.2.4/recipe-sysroot/usr/include/linux/mmc/ioctl.h:61:28: note: while referencing 'cmds'
|    61 |         struct mmc_ioc_cmd cmds[];
|       |                            ^~~~
| cc1: all warnings being treated as errors
