### PR TITLE
qtee_supplicant: harden listener startup and teardown

### DIFF
--- a/qtee_supplicant/src/listener_mngr.c
+++ b/qtee_supplicant/src/listener_mngr.c
@@ -78,7 +78,7 @@ static void deinit_listener_svc(size_t i)
  *
  * Stops all listener services waiting for a listener request from QTEE.
  */
-static void stop_listeners_services(void)
+void stop_listeners_services(void)
 {
 	size_t idx = 0;
 	size_t n_listeners = sizeof(listeners)/sizeof(struct listener_svc);
@@ -136,6 +136,7 @@ static int init_listener_svc(size_t i)
 int start_listener_services(void)
 {
 	int ret = 0;
+	int listener_count = 0;
 	size_t idx = 0;
 	size_t n_listeners = sizeof(listeners)/sizeof(struct listener_svc);
 
@@ -146,14 +147,10 @@ int start_listener_services(void)
 		ret = init_listener_svc(idx);
 		if (ret) {
 			MSGE("init_listener_svc failed: 0x%x\n", ret);
-			goto fail;
+			continue;
 		}
+		listener_count++;
 	}
 
-	return ret;
-
-fail:
-	stop_listeners_services();
-	return ret;
-
+	return listener_count;
 }

--- a/qtee_supplicant/src/listener_mngr.c
+++ b/qtee_supplicant/src/listener_mngr.c
@@ -92,12 +92,6 @@ static void stop_listeners_services(void)
 
 			listeners[idx].is_registered = false;
 		}
-
-		/* Close lib_handle for all listeners */
-		if(listeners[idx].lib_handle != NULL) {
-			dlclose(listeners[idx].lib_handle);
-			listeners[idx].lib_handle = NULL;
-		}
 	}
 }
 
@@ -130,7 +124,7 @@ static int init_listener_svc(size_t i)
 
 	ret = (*init_func)();
 	if (ret < 0) {
-		MSGE("Init for %s failed: %d", listeners[i].service_name, ret);
+		MSGE("Init for %s failed: %d\n", listeners[i].service_name, ret);
 		return -1;
 	}
 

--- a/qtee_supplicant/src/listener_mngr.h
+++ b/qtee_supplicant/src/listener_mngr.h
@@ -34,5 +34,6 @@ struct listener_svc {
  * Starts listener services which wait for a listener request from QTEE.
  */
 int start_listener_services(void);
+void stop_listeners_services(void);
 
 #endif // __LISTENER_MNGR_H

--- a/qtee_supplicant/src/qtee_supplicant.c
+++ b/qtee_supplicant/src/qtee_supplicant.c
@@ -13,7 +13,7 @@ int main() {
 
 	MSGD("qtee_supplicant: process entry PPID = %d\n", getppid());
 
-	if(0 != start_listener_services()) {
+	if(0 >= start_listener_services()) {
 		MSGE("ERROR: listeners registration failed\n");
 		return -1;
 	}
@@ -21,5 +21,6 @@ int main() {
 	MSGE("QTEE_SUPPLICANT RUNNING\n");
 	pause();
 	MSGD("qtee_supplicant: Process exiting!!!\n");
+	stop_listeners_services();
 	return -1;
 }


### PR DESCRIPTION
Make listener registration and cleanup more robust:

  - Tolerate init failures: keep starting the remaining listeners when one fails, and return the count of successfully started services instead of bailing out on the first error.
  - Export stop_listeners_services() so main() can tear down all listeners on exit.
  - Drop dlclose() during teardown: an async CBO release can call back into a listener's .so after deinit(); unmapping it there crashes with SIGSEGV. Just clear lib_handle and leave the libraries mapped for the process lifetime.
  - Fix a missing newline in the init failure log.

CRs-Fixed: 4571096
Closes: https://github.com/qualcomm/minkipc/issues/56