### PR TITLE
libminkadaptor: Fix memory object leak in TA autoload CBO

### DIFF
--- a/libminkadaptor/CMakeLists.txt
+++ b/libminkadaptor/CMakeLists.txt
@@ -66,9 +66,12 @@ set_target_properties(minkadaptor PROPERTIES
 
 # ''Headers and dependencies''.
 
+add_dependencies(minkadaptor taautoload_MINKHEADERS)
+
 target_include_directories(minkadaptor
 	PUBLIC include
 	PRIVATE src
+	PRIVATE ${CMAKE_SOURCE_DIR}/listeners/libtaautoload/idl
 )
 
 if (QCBOR_FOUND)

--- a/libminkadaptor/src/mink_adaptor.c
+++ b/libminkadaptor/src/mink_adaptor.c
@@ -6,6 +6,8 @@
 
 #include "mink_adaptor_priv.h"
 #include "supplicant.h"
+#include "IRequestTABuffer_invoke.h"
+#include "IRequestTABuffer.h"
 
 #include "MinkCom.h"
 
@@ -305,6 +307,7 @@ static void qcomtee_callback_obj_cleanup(struct qcomtee_object *object, int err)
 	struct qcomtee_callback_obj *qcomtee_cbo = CALLBACKOBJ(object);
 	uint32_t i = 0;
 
+	IRequestTABuffer_cleanup(qcomtee_cbo->mink_obj);
 	for (i = 0; i < ObjectCounts_maxBO; i++) {
 		if (qcomtee_cbo->allocated_bo[i])
 			free(qcomtee_cbo->allocated_bo[i]);

--- a/listeners/libtaautoload/CMakeLists.txt
+++ b/listeners/libtaautoload/CMakeLists.txt
@@ -67,6 +67,7 @@ set_target_properties(taautoload PROPERTIES
 target_include_directories(taautoload
 	PRIVATE idl
 	PRIVATE src
+	PRIVATE ${CMAKE_SOURCE_DIR}/listeners/listenercbo/include
 )
 
 target_link_libraries(taautoload

--- a/listeners/libtaautoload/idl/IRequestTABuffer.idl
+++ b/listeners/libtaautoload/idl/IRequestTABuffer.idl
@@ -23,6 +23,13 @@ interface IRequestTABuffer {
   */
    method get(in buffer uuid, out interface appElf);
 
+  /**
+    Release all memObj held in memObjList
+
+    @return Object_OK on success.
+  */
+   method cleanup();
+
   /* @} */ /* end_addtogroup IRequestTABuffer */
 };
 

--- a/listeners/libtaautoload/src/CRequestTABuffer.cpp
+++ b/listeners/libtaautoload/src/CRequestTABuffer.cpp
@@ -7,6 +7,7 @@
 #include "IRequestTABuffer.h"
 #include "taImageReader.h"
 #include "utils.h"
+#include "qlist.h"
 #include <fstream>
 #include <string>
 #include <vector>
@@ -17,6 +18,15 @@ using namespace std;
 static const size_t HYPHEN_LEN(4);
 static const size_t NULLCHAR_LEN(1);
 static const size_t STRING_MULTIPLIER(2);
+
+/**
+ * @brief QNode wrapper tracking a memObj handed out by CRequestTABuffer_get,
+ *        without holding an extra reference on it.
+ */
+typedef struct {
+  QNode qn;
+  Object memObj;
+} MemObjNode;
 
 /**
  * @brief Parse the device compatible string for possible device names.
@@ -86,6 +96,7 @@ static string readCompatibleString()
 static CRequestTABuffer *getCRequestTABuffer()
 {
   CRequestTABuffer * requestTABuff = new CRequestTABuffer();
+  QList_construct(&requestTABuff->memObjList);
   for (int i = 0; i < TA_PATH_LIST_SIZE; i++)
   {
     string taPaths = ta_path_list[i];
@@ -143,6 +154,34 @@ static int32_t CRequestTABuffer_retain(CRequestTABuffer *me)
 }
 
 /**
+ * @brief Release all memObj held in memObjList.
+ *
+ * Invoked before destroying the CRequestTABuffer instance to release the
+ * memObj references retained for every TA buffer handed out via
+ * CRequestTABuffer_get.
+ *
+ * @param me The local object associated with this interface.
+ * @return Object_OK
+ */
+static int32_t CRequestTABuffer_cleanup(CRequestTABuffer *me)
+{
+  QNode *node = NULL;
+  QNode *nextNode = NULL;
+  MemObjNode *memObjNode = NULL;
+
+  QLIST_NEXTSAFE_FOR_ALL(&me->memObjList, node, nextNode)
+  {
+    memObjNode = container_of(node, MemObjNode, qn);
+    Object_ASSIGN_NULL(memObjNode->memObj);
+    delete(memObjNode);
+  }
+
+  QList_construct(&me->memObjList);
+
+  return Object_OK;
+}
+
+/**
  * @brief Release the self Object.
  *
  * @param me The local object associated with this interface.
@@ -168,6 +207,7 @@ int32_t CRequestTABuffer_get(CRequestTABuffer *me, const void *uuid_ptr, size_t 
   size_t distNameLen = 0;
   TAImageReader *TAImage = nullptr;
   TEEC_UUID *pTargetUUID = NULL;
+  MemObjNode *memObjNode = NULL;
   if (uuid_len != sizeof(TEEC_UUID))
   {
     MSGE("Invalid UUID Len");
@@ -197,6 +237,11 @@ int32_t CRequestTABuffer_get(CRequestTABuffer *me, const void *uuid_ptr, size_t 
   }
 
   Object_INIT(*appElf, TAImage->getMemoryObject());
+
+  memObjNode = new MemObjNode();
+  memObjNode->memObj = TAImage->getMemoryObject();
+  QNode_construct(&memObjNode->qn);
+  QList_appendNode(&me->memObjList, &memObjNode->qn);
 
   retVal = Object_OK;
 

--- a/listeners/libtaautoload/src/CRequestTABuffer.h
+++ b/listeners/libtaautoload/src/CRequestTABuffer.h
@@ -9,6 +9,15 @@
 #include <stdint.h>
 #include <string>
 
+/* qlist.h defines container_of using void* pointer arithmetic, a GNU C
+ * extension that is ill-formed in C++ and rejected here by -Werror=pointer-arith.
+ * Override it with a char*-based definition, which is well-defined in C++. */
+#ifndef container_of
+#define container_of(ptr, type, member) \
+	((type *)((char *)(ptr) - offsetof(type, member)))
+#endif
+#include "qlist.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,6 +30,7 @@ typedef struct
 {
   std::list<std::string> searchLocations;
   Object rootObj;
+  QList memObjList;
   int refs;
 } CRequestTABuffer;
 


### PR DESCRIPTION
libtaautoload: Fix memory object leak in TA autoload CBO

CRequestTABuffer_get() hands out a memObj for each requested TA image but retains a reference on it, so every TA autoload leaked one memObj that was never released. Track each handed-out memObj in a per-instance memObjList and add an IRequestTABuffer.cleanup() method that walks the list and drops those references.

libminkadaptor invokes the new cleanup() from qcomtee_callback_obj_cleanup(), which QCOMTEE calls after the callback response has been marshalled and sent, so the references are released once the memObj is no longer needed.

Wire-up:
- Add the cleanup() method to IRequestTABuffer.idl.
- Track memObj nodes with a QList; free them in CRequestTABuffer_cleanup().
- Override container_of() in CRequestTABuffer.h with a char*-based definition, since qlist.h's void*-arithmetic version is ill-formed in C++ and rejected under -Werror=pointer-arith.
- Add the required include directories to both CMakeLists.txt files.

CRs-Fixed: 4622877
Fix-issue: https://github.com/qualcomm/minkipc/issues/9