### PR TITLE
Update qcom-preflight-checks.yml to enable commit-msg-check

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -21,6 +21,8 @@ jobs:
         enable-semgrep-scan: true              # default: true
         enable-copyright-license-check: false   # default: true
         enable-commit-email-check: true        # default: true
+        enable-commit-msg-check: true
+        commit-msg-check-extra-options: '{"body-char-limit": 75, "sub-char-limit": 60}'
         enable-dependency-review: true         # default: true
         enable-armor-checkers: true
         armor-checker-options: '{"build-script":"ci/build.sh","runs-on":{"group":"GHA-SSG-Prd-SelfHosted-RG","labels":["self-hosted","ssg-prd-u2204-x64-large-od-ephem"]}}'


### PR DESCRIPTION
Enables commit-msg-check action to ensure proper formatting of commit messages

default limits for subject and body line wrap:

 body-line-wrap-limit: 75
 sub-char-limit: 60