### PR TITLE
ci: Fix trailing whitespace after line continuation in docker run

### DIFF
--- a/.github/workflows/sync_build.yml
+++ b/.github/workflows/sync_build.yml
@@ -219,7 +219,7 @@ jobs:
           docker run --rm --privileged --user root \
             -v "${{ github.workspace }}/..:${{ github.workspace }}/.." \
             -e GITHUB_WORKSPACE="${{ github.workspace }}" \
-            -e MATRIX_NAME="${{ matrix.name }}" \                                                         
+            -e MATRIX_NAME="${{ matrix.name }}" \
             "${{ inputs.docker_image }}" \
             bash -lc '
               set -euxo pipefail


### PR DESCRIPTION
Trailing whitespace after the backslash on the -e MATRIX_NAME line broke bash line continuation, causing docker to receive a whitespace literal as the image name instead of inputs.docker_image, resulting in "invalid reference format". Remove the whitespace to fix it.

CRs-Fixed: 4538047